### PR TITLE
Add UpdateApplianceMetadata call

### DIFF
--- a/cloudkeeper.proto
+++ b/cloudkeeper.proto
@@ -55,6 +55,7 @@ service Communicator {
   rpc PostAction(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc AddAppliance(Appliance) returns (google.protobuf.Empty) {}
   rpc UpdateAppliance(Appliance) returns (google.protobuf.Empty) {}
+  rpc UpdateApplianceMetadata(Appliance) returns (google.protobuf.Empty) {}
   rpc RemoveAppliance(Appliance) returns (google.protobuf.Empty) {}
   rpc RemoveImageList(ImageListIdentifier) returns (google.protobuf.Empty) {}
   rpc ImageLists(google.protobuf.Empty) returns (stream ImageListIdentifier) {}


### PR DESCRIPTION
With this additional call it will be easy to distinguish whether we're
doing only metadata update or full update with new appliance image.