### PR TITLE
Add method for expired appliance removal

### DIFF
--- a/cloudkeeper.proto
+++ b/cloudkeeper.proto
@@ -60,4 +60,5 @@ service Communicator {
   rpc RemoveImageList(ImageListIdentifier) returns (google.protobuf.Empty) {}
   rpc ImageLists(google.protobuf.Empty) returns (stream ImageListIdentifier) {}
   rpc Appliances(ImageListIdentifier) returns (stream Appliance) {}
+  rpc RemoveExpiredAppliances(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }


### PR DESCRIPTION
This functionality was so far part of the pre/post actions but since
it's a common functionality for all CMFs it should be a separate method.